### PR TITLE
rolled back @prisma/client version to v3 from v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "prisma": "^4.0.0"
   },
   "dependencies": {
-    "@prisma/client": "^4.0.0",
+    "@prisma/client": "^3.14.0",
     "godspeed-crud-api-generator": "^1.4.0",
     "newman": "^5.3.2",
     "openapi-to-postmanv2": "^3.2.1"


### PR DESCRIPTION
There was some error because of v4 while generating prisma client.