### PR TITLE
Update godspeed-crud-api-generator to 1.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@prisma/client": "^3.14.0",
-    "godspeed-crud-api-generator": "^1.4.0",
+    "godspeed-crud-api-generator": "^1.4.1",
     "newman": "^5.3.2",
     "openapi-to-postmanv2": "^3.2.1"
   }


### PR DESCRIPTION
godspeed-crud-api-generator@1.4.1 fixes all the issues about metrics.